### PR TITLE
Add option to export loop as video

### DIFF
--- a/giffer
+++ b/giffer
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-# usage: input-file output-file start-time end-time
+# usage: <gif|video> input-file output-dir start-time end-time
 
 # input-file is the input video
-# output-file is the name of the output file (should probably end with .gif if you want a gif file)
-# start-time is the start of the gif
-# end-time is the end of the gif
+# output-dir is the directory where you want to save the output file
+# start-time is the start of the clip
+# end-time is the end of the clip
 
-start_time=$3
-end_time=$4
+start_time=$4
+end_time=$5
 
 if [[ "$start_time" == "no" || "$end_time" == "no" ]]; then
    echo "No start/end points defined; exiting..."
@@ -19,12 +19,21 @@ duration=$(echo $end_time - $start_time | bc)
 
 duration=$(printf '%f' $duration)
 
-palette="/tmp/palette.png"
+fps=$(ffmpeg -i "$2" 2>&1 | sed -n "s/.*, \(.*\) fp.*/\1/p")
 
-fps=$(ffmpeg -i "$1" 2>&1 | sed -n "s/.*, \(.*\) fp.*/\1/p")
-
-# filters="fps=$fps,scale=320:(320/(iw*sar))*ih:flags=lanczos" # uncomment this line and comment out the next one to force the output gif to a width of 320px.
+# filters="fps=$fps,scale=320:(320/(iw*sar))*ih:flags=lanczos" # uncomment this line and comment out the next one to force a width of 320px.
 filters="fps=$fps,scale=iw*sar:ih:flags=lanczos"
 
-ffmpeg -v warning -ss $start_time -t $duration -i "$1" -vf "$filters,palettegen" -y $palette
-ffmpeg -v warning -ss $start_time -t $duration -i "$1" -i $palette -lavfi "$filters [x]; [x][1:v] paletteuse" -y "$2"
+filename=$(echo $2 | sed "s/.*\/\(.*\)\..*$/\1/")
+
+if [[ "$1" == "gif" ]]; then
+    palette="/tmp/palette.png"
+    ffmpeg -v warning -ss $start_time -t $duration -i "$2" -vf "$filters,palettegen" -y $palette
+    ffmpeg -v warning -ss $start_time -t $duration -i "$2" -i $palette -lavfi "$filters [x]; [x][1:v] paletteuse" -y "$3/$filename $start_time.gif"
+elif [[ "$1" == "video" ]]; then
+    extension=$(echo $2 | sed "s/.*\.\(.*\)$/\1/")
+    ffmpeg -v warning -ss $start_time -i "$2" -t $duration -vf "$filters" -y "$3/$filename $start_time.$extension"
+else
+    echo "First argument isn't \"gif\" or \"video\"; exiting..."
+    exit 1
+fi

--- a/giffer
+++ b/giffer
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-# usage: <gif|video> input-file output-dir start-time end-time
+# usage: input-file output-file start-time end-time
 
 # input-file is the input video
-# output-dir is the directory where you want to save the output file
+# output-file is the name of the output file, or a directory in which to save the output file
 # start-time is the start of the clip
 # end-time is the end of the clip
 
-start_time=$4
-end_time=$5
+start_time=$3
+end_time=$4
 
 if [[ "$start_time" == "no" || "$end_time" == "no" ]]; then
    echo "No start/end points defined; exiting..."
@@ -19,21 +19,23 @@ duration=$(echo $end_time - $start_time | bc)
 
 duration=$(printf '%f' $duration)
 
-fps=$(ffmpeg -i "$2" 2>&1 | sed -n "s/.*, \(.*\) fp.*/\1/p")
+fps=$(ffmpeg -i "$1" 2>&1 | sed -n "s/.*, \(.*\) fp.*/\1/p")
 
 # filters="fps=$fps,scale=320:(320/(iw*sar))*ih:flags=lanczos" # uncomment this line and comment out the next one to force a width of 320px.
 filters="fps=$fps,scale=iw*sar:ih:flags=lanczos"
 
-filename=$(echo $2 | sed "s/.*\/\(.*\)\..*$/\1/")
+input_filename=$(echo $1 | sed "s/.*\/\(.*\)\..*$/\1/")
+input_extension=$(echo $1 | sed "s/.*\.\(.*\)$/\1/")
+output_extension=$(echo $2 | sed "s/.*\.\(.*\)$/\1/")
 
-if [[ "$1" == "gif" ]]; then
+if [[ "$output_extension" == "gif" ]]; then
     palette="/tmp/palette.png"
-    ffmpeg -v warning -ss $start_time -t $duration -i "$2" -vf "$filters,palettegen" -y $palette
-    ffmpeg -v warning -ss $start_time -t $duration -i "$2" -i $palette -lavfi "$filters [x]; [x][1:v] paletteuse" -y "$3/$filename $start_time.gif"
-elif [[ "$1" == "video" ]]; then
-    extension=$(echo $2 | sed "s/.*\.\(.*\)$/\1/")
-    ffmpeg -v warning -ss $start_time -i "$2" -t $duration -vf "$filters" -y "$3/$filename $start_time.$extension"
+    ffmpeg -v warning -ss $start_time -t $duration -i "$1" -vf "$filters,palettegen" -y $palette
+    ffmpeg -v warning -ss $start_time -t $duration -i "$1" -i $palette -lavfi "$filters [x]; [x][1:v] paletteuse" -y "$2"
 else
-    echo "First argument isn't \"gif\" or \"video\"; exiting..."
-    exit 1
+    if [[ -d "$2" ]]; then # $2 is a directory
+        ffmpeg -v warning -ss $start_time -i "$1" -t $duration -vf "$filters" -y "$2/$input_filename $start_time.$input_extension"
+    else
+        ffmpeg -v warning -ss $start_time -i "$1" -t $duration -vf "$filters" -y "$2"
+    fi
 fi

--- a/input.conf
+++ b/input.conf
@@ -1,1 +1,2 @@
-g run "/bin/sh" "/path/to/giffer" "${path}" "/path/where/you/want/to/save/the/output/${filename/no-ext} ${=ab-loop-a}.gif" "${=ab-loop-a}" "${=ab-loop-b}"
+g run "/path/to/giffer" gif "${path}" "/path/where/you/want/to/save/the/output" "${=ab-loop-a}" "${=ab-loop-b}"
+h run "/path/to/giffer" video "${path}" "/path/where/you/want/to/save/the/output" "${=ab-loop-a}" "${=ab-loop-b}"

--- a/input.conf
+++ b/input.conf
@@ -1,2 +1,2 @@
-g run "/path/to/giffer" gif "${path}" "/path/where/you/want/to/save/the/output" "${=ab-loop-a}" "${=ab-loop-b}"
-h run "/path/to/giffer" video "${path}" "/path/where/you/want/to/save/the/output" "${=ab-loop-a}" "${=ab-loop-b}"
+g run "/path/to/giffer" "${path}" "/path/where/you/want/to/save/the/output/${filename/no-ext} ${=ab-loop-a}.gif" "${=ab-loop-a}" "${=ab-loop-b}"
+h run "/path/to/giffer" "${path}" "/path/where/you/want/to/save/the/output" "${=ab-loop-a}" "${=ab-loop-b}"


### PR DESCRIPTION
This is a bigger change than my last two PRs, and it's fine if you don't think it fits in giffer.

The natural key to bind it to would be v, but that's already taken in mpv's default bindings. Also, I had to change the "output file" script argument to "output dir", since I wanted to keep the extension of the input video. A bit clunky.

Cheers!

